### PR TITLE
Add 1.10.2 download and alternate 1.9.4 download

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,9 +74,12 @@
             your needs, and you're free to change it however you want.</p>
         <div class="row">
             <div class="col-md-6">
-                <a href="https://bamboo.gserv.me/browse/GSPP-SRV/latestSuccessful/artifact/shared/Server-JAR/glowstone%2B%2B-1.9.4-SNAPSHOT.jar"
+                <a href="https://bamboo.gserv.me/browse/GSPP-SRV/latestSuccessful/artifact/shared/Server-JAR/glowstone%2B%2B-1.10.2-SNAPSHOT.jar"
                    class="btn btn-primary"><i class="fa fa-download fa-fw"></i> Download for
-                    1.9.4
+                    1.10.2
+                </a>
+                <a href="https://github.com/GlowstoneMC/Glowstone/releases/download/1.9.4/glowstone.-1.9.4-SNAPSHOT.jar"
+                   class="btn btn-info">1.9.4
                 </a>
             </div>
             <div class="hidden-md-up"><br></div>


### PR DESCRIPTION
Adds the 1.10.2 latest download link, as well as an alternate 1.9.4 download button.

This is what it looks like: ![screeny](http://image.prntscr.com/image/f0cc1270f6f745b2ac81d12e8fbda5f9.png)

(That way, we won't have constant questions about where to download 1.9.4)
